### PR TITLE
feat: setup docker-compose based deployment for NTC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # nautilus-trusted-compute-deployment
 This is a Docker Compose based deployment of [nautilus-trusted-compute](https://github.com/ntls-io/nautilus-trusted-compute).
+
+## Services
+
+### HTTP ingress: `nginx-proxy`
+
+This runs [nginx-proxy] and exposes ports 80 and 443, forwarding HTTP requests through to the other services (which listen on internal ports).
+
+[nginx-proxy]: https://github.com/nginx-proxy/nginx-proxy
+
+#### Configuration
+
+TLS certificates are mounted from `/etc/nginx/certs` on the host, and the proxied services use `VIRTUAL_HOST` and `CERT_NAME` to configure which host name and certificate should proxy to them.
+
+### Vault APIs: `vault-*-api`
+
+These run the individual Wallet TEEs using the host's SGX devices, each with a Docker volume to persist wallet state (`/app/wallet_store`).
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,8 +14,8 @@ services:
       - vault-staging
       - vault-main
     ports:
-      - "80:80"
-      - "443:443"
+      - "8080:80"
+      - "8443:443"
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
       - /etc/tls:/etc/nginx/certs:ro

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,80 @@
+# Nautilus Wallet demo and staging deployment
+
+networks:
+  vault-dev:
+  vault-staging:
+  vault-main:
+
+services:
+  # Docs: https://github.com/nginx-proxy/nginx-proxy
+  nginx-proxy:
+    image: nginxproxy/nginx-proxy:alpine
+    networks:
+      - vault-dev
+      - vault-staging
+      - vault-main
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - /etc/tls:/etc/nginx/certs:ro
+
+  vault-dev-api:
+    image: ghcr.io/ntls-io/sgx-vault-hw:main
+    environment:
+      VIRTUAL_HOST: nautilus-trust-dev-api.ntls.io
+      BIND_ADDR: "0.0.0.0:8080"
+      CERT_NAME: ntls-api
+    networks:
+      - vault-dev
+    volumes:
+      - vault-store-dev:/app/vault_store
+    read_only: true
+    init: true
+    devices:
+      - /dev/sgx/enclave
+      - /dev/sgx/provision
+    expose:
+      - "8080"
+
+  vault-staging-api:
+    image: ghcr.io/ntls-io/sgx-vault-hw:main
+    environment:
+      VIRTUAL_HOST: nautilus-trust-staging-api.ntls.io
+      BIND_ADDR: "0.0.0.0:8080"
+      CERT_NAME: ntls-api
+    networks:
+      - vault-staging
+    volumes:
+      - vault-store-staging:/app/vault_store
+    read_only: true
+    init: true
+    devices:
+      - /dev/sgx/enclave
+      - /dev/sgx/provision
+    expose:
+      - "8080"
+
+  vault-main-api:
+    image: ghcr.io/ntls-io/sgx-vault-hw:main
+    environment:
+      VIRTUAL_HOST: nautilus-trust-main-api.ntls.io
+      BIND_ADDR: "0.0.0.0:8080"
+      CERT_NAME: ntls-api
+    networks:
+      - vault-main
+    volumes:
+      - vault-store-main:/app/vault_store
+    read_only: true
+    init: true
+    devices:
+      - /dev/sgx/enclave
+      - /dev/sgx/provision
+    expose:
+      - "8080"
+
+volumes:
+  vault-store-dev:
+  vault-store-staging:
+  vault-store-main:


### PR DESCRIPTION
This PR will add docker-compose.yml file to help deploy web-servers for sgx-vault for 3 environments (dev, staging and main).